### PR TITLE
Fix link on API collection and entity selection classes

### DIFF
--- a/docs/FormObjects/listbox_overview.md
+++ b/docs/FormObjects/listbox_overview.md
@@ -550,8 +550,8 @@ Standard sort support depends on the list box type:
 |List box type|Support of standard sort|Comments|
 |---|---|---|
 |Collection of objects|Yes|<li>"This.a" or "This.a.b" columns are sortable.</li><li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li>|
-|Collection of scalar values|No|Use custom sort with [`orderBy()`](..\API\CollectionClass.md#orderby) function|
-|Entity selection|Yes|<li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li><li>Supported: sorts on object attribute properties (e.g. "This.data.city" when "data" is an object attribute)</li><li>Supported: sorts on related attributes (e.g. "This.company.name")</li><li>Not supported: sorts on object attribute properties through related attributes (e.g. "This.company.data.city"). For this, you need to use custom sort with [`orderByFormula()`](..\API\EntitySelectionClass.md#orderbyformula) function (see example below)</li>|
+|Collection of scalar values|No|Use custom sort with [`orderBy()`](../API/CollectionClass.md#orderby) function|
+|Entity selection|Yes|<li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li><li>Supported: sorts on object attribute properties (e.g. "This.data.city" when "data" is an object attribute)</li><li>Supported: sorts on related attributes (e.g. "This.company.name")</li><li>Not supported: sorts on object attribute properties through related attributes (e.g. "This.company.data.city"). For this, you need to use custom sort with [`orderByFormula()`](../API/EntitySelectionClass.md#orderbyformula) function (see example below)</li>|
 |Current selection|Yes|Only simple expressions are sortable (e.g. `[Table_1]Field_2`)|
 |Named selection|No||
 |Arrays|Yes|Columns bound to picture and pointer arrays are not sortable|
@@ -566,7 +566,7 @@ The developer can set up custom sorts, for example using the [`LISTBOX SORT COLU
 Custom sorts allow you to:
 
 - carry out multi-level sorts on several columns, thanks to the [`LISTBOX SORT COLUMNS`](https://doc.4d.com/4dv19/help/command/en/page916.html) command,
-- use functions such as [`collection.orderByFormula()`](..\API\CollectionClass.md#orderbyformula) or [`entitySelection.orderByFormula()`](..\API\EntitySelectionClass.md#orderbyformula) to sort columns on complex criteria. 
+- use functions such as [`collection.orderByFormula()`](../API/CollectionClass.md#orderbyformula) or [`entitySelection.orderByFormula()`](../API/EntitySelectionClass.md#orderbyformula) to sort columns on complex criteria. 
 
 #### Example
 

--- a/versioned_docs/version-19-R7/FormObjects/listbox_overview.md
+++ b/versioned_docs/version-19-R7/FormObjects/listbox_overview.md
@@ -550,8 +550,8 @@ Standard sort support depends on the list box type:
 |List box type|Support of standard sort|Comments|
 |---|---|---|
 |Collection of objects|Yes|<li>"This.a" or "This.a.b" columns are sortable.</li><li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li>|
-|Collection of scalar values|No|Use custom sort with [`orderBy()`](..\API\CollectionClass.md#orderby) function|
-|Entity selection|Yes|<li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li><li>Supported: sorts on object attribute properties (e.g. "This.data.city" when "data" is an object attribute)</li><li>Supported: sorts on related attributes (e.g. "This.company.name")</li><li>Not supported: sorts on object attribute properties through related attributes (e.g. "This.company.data.city"). For this, you need to use custom sort with [`orderByFormula()`](..\API\EntitySelectionClass.md#orderbyformula) function (see example below)</li>|
+|Collection of scalar values|No|Use custom sort with [`orderBy()`](../API/CollectionClass.md#orderby) function|
+|Entity selection|Yes|<li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li><li>Supported: sorts on object attribute properties (e.g. "This.data.city" when "data" is an object attribute)</li><li>Supported: sorts on related attributes (e.g. "This.company.name")</li><li>Not supported: sorts on object attribute properties through related attributes (e.g. "This.company.data.city"). For this, you need to use custom sort with [`orderByFormula()`](../API/EntitySelectionClass.md#orderbyformula) function (see example below)</li>|
 |Current selection|Yes|Only simple expressions are sortable (e.g. `[Table_1]Field_2`)|
 |Named selection|No||
 |Arrays|Yes|Columns bound to picture and pointer arrays are not sortable|
@@ -566,7 +566,7 @@ The developer can set up custom sorts, for example using the [`LISTBOX SORT COLU
 Custom sorts allow you to:
 
 - carry out multi-level sorts on several columns, thanks to the [`LISTBOX SORT COLUMNS`](https://doc.4d.com/4dv19/help/command/en/page916.html) command,
-- use functions such as [`collection.orderByFormula()`](..\API\CollectionClass.md#orderbyformula) or [`entitySelection.orderByFormula()`](..\API\EntitySelectionClass.md#orderbyformula) to sort columns on complex criteria. 
+- use functions such as [`collection.orderByFormula()`](../API/CollectionClass.md#orderbyformula) or [`entitySelection.orderByFormula()`](../API/EntitySelectionClass.md#orderbyformula) to sort columns on complex criteria. 
 
 #### Example
 

--- a/versioned_docs/version-19-R8/FormObjects/listbox_overview.md
+++ b/versioned_docs/version-19-R8/FormObjects/listbox_overview.md
@@ -550,8 +550,8 @@ Standard sort support depends on the list box type:
 |List box type|Support of standard sort|Comments|
 |---|---|---|
 |Collection of objects|Yes|<li>"This.a" or "This.a.b" columns are sortable.</li><li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li>|
-|Collection of scalar values|No|Use custom sort with [`orderBy()`](..\API\CollectionClass.md#orderby) function|
-|Entity selection|Yes|<li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li><li>Supported: sorts on object attribute properties (e.g. "This.data.city" when "data" is an object attribute)</li><li>Supported: sorts on related attributes (e.g. "This.company.name")</li><li>Not supported: sorts on object attribute properties through related attributes (e.g. "This.company.data.city"). For this, you need to use custom sort with [`orderByFormula()`](..\API\EntitySelectionClass.md#orderbyformula) function (see example below)</li>|
+|Collection of scalar values|No|Use custom sort with [`orderBy()`](../API/CollectionClass.md#orderby) function|
+|Entity selection|Yes|<li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li><li>Supported: sorts on object attribute properties (e.g. "This.data.city" when "data" is an object attribute)</li><li>Supported: sorts on related attributes (e.g. "This.company.name")</li><li>Not supported: sorts on object attribute properties through related attributes (e.g. "This.company.data.city"). For this, you need to use custom sort with [`orderByFormula()`](../API/EntitySelectionClass.md#orderbyformula) function (see example below)</li>|
 |Current selection|Yes|Only simple expressions are sortable (e.g. `[Table_1]Field_2`)|
 |Named selection|No||
 |Arrays|Yes|Columns bound to picture and pointer arrays are not sortable|
@@ -566,7 +566,7 @@ The developer can set up custom sorts, for example using the [`LISTBOX SORT COLU
 Custom sorts allow you to:
 
 - carry out multi-level sorts on several columns, thanks to the [`LISTBOX SORT COLUMNS`](https://doc.4d.com/4dv19/help/command/en/page916.html) command,
-- use functions such as [`collection.orderByFormula()`](..\API\CollectionClass.md#orderbyformula) or [`entitySelection.orderByFormula()`](..\API\EntitySelectionClass.md#orderbyformula) to sort columns on complex criteria. 
+- use functions such as [`collection.orderByFormula()`](../API/CollectionClass.md#orderbyformula) or [`entitySelection.orderByFormula()`](../API/EntitySelectionClass.md#orderbyformula) to sort columns on complex criteria. 
 
 #### Example
 

--- a/versioned_docs/version-19/FormObjects/listbox_overview.md
+++ b/versioned_docs/version-19/FormObjects/listbox_overview.md
@@ -518,8 +518,8 @@ Standard sort support depends on the list box type:
 |List box type|Support of standard sort|Comments|
 |---|---|---|
 |Collection of objects|Yes|<li>"This.a" or "This.a.b" columns are sortable.</li><li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li>|
-|Collection of scalar values|No|Use custom sort with [`orderBy()`](..\API\CollectionClass.md#orderby) function|
-|Entity selection|Yes|<li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li><li>Supported: sorts on object attribute properties (e.g. "This.data.city" when "data" is an object attribute)</li><li>Supported: sorts on related attributes (e.g. "This.company.name")</li><li>Not supported: sorts on object attribute properties through related attributes (e.g. "This.company.data.city"). For this, you need to use custom sort with [`orderByFormula()`](..\API\EntitySelectionClass.md#orderbyformula) function (see example below)</li>|
+|Collection of scalar values|No|Use custom sort with [`orderBy()`](../API/CollectionClass.md#orderby) function|
+|Entity selection|Yes|<li>The [list box source property](properties_Object.md#variable-or-expression) must be an [assignable expression](../Concepts/quick-tour.md#assignable-vs-non-assignable-expressions).</li><li>Supported: sorts on object attribute properties (e.g. "This.data.city" when "data" is an object attribute)</li><li>Supported: sorts on related attributes (e.g. "This.company.name")</li><li>Not supported: sorts on object attribute properties through related attributes (e.g. "This.company.data.city"). For this, you need to use custom sort with [`orderByFormula()`](../API/EntitySelectionClass.md#orderbyformula) function (see example below)</li>|
 |Current selection|Yes|Only simple expressions are sortable (e.g. `[Table_1]Field_2`)|
 |Named selection|No||
 |Arrays|Yes|Columns bound to picture and pointer arrays are not sortable|
@@ -531,7 +531,7 @@ The developer can set up custom sorts, for example using the [`LISTBOX SORT COLU
 Custom sorts allow you to:
 
 * carry out multi-level sorts on several columns, thanks to the [`LISTBOX SORT COLUMNS`](https://doc.4d.com/4dv19/help/command/en/page916.html) command,
-* use functions such as [`collection.orderByFormula()`](..\API\CollectionClass.md#orderbyformula) or [`entitySelection.orderByFormula()`](..\API\EntitySelectionClass.md#orderbyformula) to sort columns on complex criteria.
+* use functions such as [`collection.orderByFormula()`](../API/CollectionClass.md#orderbyformula) or [`entitySelection.orderByFormula()`](../API/EntitySelectionClass.md#orderbyformula) to sort columns on complex criteria.
 
 #### Example
 


### PR DESCRIPTION
to avoid warning such as

```diff
- [WARNING] Docs markdown link couldn't be resolved: (..\API\CollectionClass.md) in "/Users/emarchand/git/cloud/docs/docs/FormObjects/listbox_overview.md" for version current
- [WARNING] Docs markdown link couldn't be resolved: (..\API\EntitySelectionClass.md) in "/Users/emarchand/git/cloud/docs/docs/FormObjects/listbox_overview.md" for version current
```

`\API\` -> `/API/`